### PR TITLE
Create new toml version of alacritty

### DIFF
--- a/lua/termcolors.lua
+++ b/lua/termcolors.lua
@@ -5,7 +5,8 @@ local helpers = require'termcolors/helpers'
 -- Provided plugins
 termcolors.plugins = {
 	["kitty"] = require'termcolors/plugins/kitty',
-	["alacritty"] = require'termcolors/plugins/alacritty'
+	["alacritty"] = require'termcolors/plugins/alacritty',
+	["alacritty-yaml"] = require'termcolors/plugins/alacritty-yaml'
 }
 
 -- The default plugin to use


### PR DESCRIPTION
Alacritty has moved to a toml based configuration format.

Update the alacritty plugin to output this toml format, while moving the old yaml format to the `alacritty-yaml` plugin.